### PR TITLE
Remove title map load

### DIFF
--- a/SRC/bank_000.asm
+++ b/SRC/bank_000.asm
@@ -3779,10 +3779,6 @@ poseFunc_crouch: ;{ 00:15F4 - $04: Crouching
         jr z, .endIf_K
             ld a, [samus_jumpArcCounter]
             add $10
-			;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;nextCheck
-			nop
-			;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;endcheck
-
             ld [samus_jumpArcCounter], a
         .endIf_K:
     
@@ -10924,9 +10920,3 @@ unusedDeathAnimation_copy: ;{ 00:3F07
 reti ;}
 
 bank0_freespace: ; Freespace - 00:3F60 (filled with $00)
-
-;new code
-m2maps_doHandleLoadMapTiles_farCall:
-    callFar m2maps_farLoadMapTiles
-    switchBank m2maps_handleLoadMapTiles
-    ret

--- a/SRC/bank_005.asm
+++ b/SRC/bank_005.asm
@@ -145,14 +145,9 @@ loadTitleScreen: ;{ 05:408F
         inc de
         dec b
     jr nz, .hudLoop
-        ; m2maps: initial load of map tiles at game start
-			call m2maps_doHandleLoadMapTiles_hijack
-        ;    m2maps_handleLoadMapTiles:
-        ;    call m2maps_doHandleLoadMapTiles_farCall
-        ; end m2maps block
-    ; Load "Save" text
 ;this next line commented and moved with above block to preserve byte locations for LAMP
-;    ld hl, saveTextTilemap
+    ; Load "Save" text
+    ld hl, saveTextTilemap
     ld de, vramDest_itemText
     ld b, $14
     .saveTextLoop:
@@ -1598,14 +1593,3 @@ gfx_theEnd: incbin "gfx/titleCredits/theEnd.chr"
 bank5_freespace: ; 05:7F34 -- filled with $00 (nop)
 
 ;EoF
-
-; m2maps: actual hijack to preserve byte addresses
-; does initial load of map tiles at game start
-	m2maps_doHandleLoadMapTiles_hijack:
-	m2maps_handleLoadMapTiles:
-	call m2maps_doHandleLoadMapTiles_farCall
-		;relocated from hijack to preserve vanilla ROM addresses:
-		ld hl, saveTextTilemap
-	;revert OG code and return from hijack
-	ret
-; end m2maps block

--- a/SRC/bank_010.asm
+++ b/SRC/bank_010.asm
@@ -213,9 +213,9 @@ m2maps_farLoadMapTiles:
 	.loadMapIconData:
 		ld a, [hl+]
         ld [de], a
-		cp a, icon_array_terminator
-		jr z, .next
 		inc de
+		cp a, endList
+		jr z, .next
 		jr .loadMapIconData
 	.next:
 		inc de

--- a/SRC/mapPatchTables/mapTileConstants.asm
+++ b/SRC/mapPatchTables/mapTileConstants.asm
@@ -87,7 +87,6 @@ def flipR = $20	;right flip
 
 ;how map sprite arrays are done:
 ;auto-validate address:
-def icon_array_terminator = $ff
 def autoVal = $c0
 def endList = $ff
 def validateBank9 = $c9


### PR DESCRIPTION
-unnecessary since map loads on warp into landing site -having no currentLevelBank value, loaded garbage data and broke the stack -able to clean up bank 5 and also some extraneous code in bank 0 as a result